### PR TITLE
feat: update node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 16, 18]
+        node-version:
+          - 14
+          - 16
+          - 18
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Automated changes by [update-node-versions](https://github.com/hongaar/pdate-node-versions) GitHub action

BREAKING CHANGE: This updates the supported node.js versions